### PR TITLE
Fix typo

### DIFF
--- a/init.qcom.rc
+++ b/init.qcom.rc
@@ -183,7 +183,7 @@ on boot
     chown system system /sys/devices/soc.0/f9924000.i2c/i2c-2/2-0070/input/input1/wake_gesture
 
     #keydisabler
-    chowm system system /sys/devices/soc.0/f9924000.i2c/i2c-2/2-0070/input/input1/0dbutton
+    chown system system /sys/devices/soc.0/f9924000.i2c/i2c-2/2-0070/input/input1/0dbutton
 
     #torch
     chown system system /sys/class/leds/led:torch_0/brightness


### PR DESCRIPTION
One more typo noticed in https://github.com/MoKee/android_device_xiaomi_libra/commit/f0bea4fbf9c7379336a5bb17d0c3adf5a86b3120#commitcomment-16813120
